### PR TITLE
Modify SSL version from SSLv3 to TLSv1.2

### DIFF
--- a/lib/cash_poster/transaction.rb
+++ b/lib/cash_poster/transaction.rb
@@ -13,7 +13,7 @@ module CashPoster
         http = Net::HTTP.new(uri.host, uri.port)
       end
       http.use_ssl = true
-      http.ssl_version = 'SSLv3'
+      http.ssl_version = 'TLSv1_2'
       http_req = Net::HTTP::Post.new(uri.path)
       http_req.body = request.params.to_query
       http_res = http.request(http_req)


### PR DESCRIPTION
I changed the protocol version of SSL to TLSv1.2 because CASHPOST disabled SSLv3.

```
OpenSSL::SSL::SSLError - SSL_connect returned=1 errno=0 state=error: sslv3 alert handshake failure
${HOME}/.rbenv/versions/2.0.0-p647/lib/ruby/2.0.0/net/http.rb:921:in `connect'
```